### PR TITLE
Expand claude workflow review permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,10 @@ jobs:
         github.event.comment.author_association == 'COLLABORATOR' ||
         github.event.issue.author_association == 'OWNER' ||
         github.event.issue.author_association == 'MEMBER' ||
-        github.event.issue.author_association == 'COLLABORATOR'
+        github.event.issue.author_association == 'COLLABORATOR' ||
+        github.event.review.author_association == 'OWNER' ||
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'COLLABORATOR'
       )
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- allow Claude workflow to respond to pull request reviews from trusted associations
- include review author association checks alongside existing comment and issue checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e50b7578a0832b800d820350858256